### PR TITLE
Removing errors while receiving an empty response

### DIFF
--- a/src/common/api.js
+++ b/src/common/api.js
@@ -66,7 +66,8 @@ exports.stream = function (query, user, options, callback) {
         try {
             return JSON.parse(str);
         } catch(e) {
-            cli.log.error('Parsing error:' + str + '\n');
+            if(str!="")
+                cli.log.error('Parsing error:' + str + '\n');
         }
     }))
     .on('data', function(data) {
@@ -103,7 +104,8 @@ exports.timeline = function (user, options, callback) {
         try {
             return JSON.parse(str);
         } catch(e) {
-            cli.log.error('Parsing error:' + str + '\n');
+            if(str!="")
+                cli.log.error('Parsing error:' + str + '\n');
         }
     }))
     .on('data', function(data) {

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -66,8 +66,9 @@ exports.stream = function (query, user, options, callback) {
         try {
             return JSON.parse(str);
         } catch(e) {
-            if(str!="")
+            if(str!==''){
                 cli.log.error('Parsing error:' + str + '\n');
+            }
         }
     }))
     .on('data', function(data) {
@@ -104,8 +105,9 @@ exports.timeline = function (user, options, callback) {
         try {
             return JSON.parse(str);
         } catch(e) {
-            if(str!="")
+            if(str!==''){
                 cli.log.error('Parsing error:' + str + '\n');
+            }
         }
     }))
     .on('data', function(data) {


### PR DESCRIPTION
Removing showing errors like: "error:   Parsing error:"
When an empty response is received.

This is an annoying error when you are streaming an tag that's not all time updated or you're seeing your timeline.