### PR TITLE
Provide a new cli flag for keeping new lines in tweets

### DIFF
--- a/src/commands/timeline.js
+++ b/src/commands/timeline.js
@@ -16,16 +16,19 @@ var stream = function () {
 
 
         api.timeline(user, function(tweet) {
-            if (tweet && tweet.user) {
-                if (cli.argv.json) {
-                    console.log(JSON.stringify(tweet));
-                } else {
-                    console.log(
-                        ('@' + tweet.user.screen_name + ':').cyan.bold,
-                        tweet.text.replace(/[\n\r]+/g, '')
-                    );
-                }
+            if (!tweet || !tweet.user) {
+                return;
             }
+
+            if (cli.argv.json) {
+                console.log(JSON.stringify(tweet));
+                return;
+            }
+
+            var tweetUserName = ('@' + tweet.user.screen_name + ':').cyan.bold;
+            var tweetText = cli.argv['keep-new-lines'] ? tweet.text : tweet.text.replace(/[\n\r]+/g, '¬');
+
+            console.log(tweetUserName, tweetText);
         });
     });
 };

--- a/src/common/usage.js
+++ b/src/common/usage.js
@@ -50,6 +50,8 @@ module.exports = [
     'To start streaming your timeline'.cyan,
     ' tweet timeline',
     'or'.cyan,
+    ' tweet timeline --keep-new-lines',
+    'or'.cyan,
     ' tweet timeline --json',
     'Warning: The latter option dumps a lot of json in your console.',
     '',


### PR DESCRIPTION
Now you can run `tweet timeline --keep-new-lines` and get a tweet with new lines.

Also added a fancy unicode symbol for marking new lines visible in case we don't want them to break a tweet.